### PR TITLE
This adds support to the putdata script for dumping out the RDF

### DIFF
--- a/putData.sh
+++ b/putData.sh
@@ -69,6 +69,7 @@ WIKI_ID=$(cat ./$TO_WIKI_DOMAIN/details.json | jq -r '.id')
 WIKI_DB=$(cat ./$TO_WIKI_DOMAIN/details.json | jq -r '.wiki_db.name')
 WIKI_DB_USER=$(cat ./$TO_WIKI_DOMAIN/details.json | jq -r '.wiki_db.user')
 WIKI_DB_PASS=$(cat ./$TO_WIKI_DOMAIN/details.json | jq -r '.wiki_db.password')
+WIKI_QS_NAMESPACE=$(cat ./$TO_WIKI_DOMAIN/details.json | jq -r '.wiki_queryservice_namespace.namespace')
 
 echo $WIKI_DB
 
@@ -95,24 +96,24 @@ LOCAL_SQL_PATH=./$FROM_WIKI_DOMAIN/db.sql
 # TODO run all jobs
 
 # Fill QueryService
-WBS_DOMAIN=wikibasederp.wbaas.localhost
-QS_POD=queryservice-55fcdbcf86-x7db2
-QS_NAMESPACE=qsns_b247111900
+QS_POD=$($CLOUD_KUBECTL get pods -l app.kubernetes.io/name=queryservice -o jsonpath="{.items[0].metadata.name}")
 
 ## To clear a namespace from things
 ## curl 'http://localhost:9999/bigdata/namespace/qsns_b247111900/sparql' -X POST --data-raw 'update=DROP ALL;'
 
-CLOUD_KUBECTL="kubectl --context=minikube-wbaas"
-MW_POD=$($CLOUD_KUBECTL get pods -l app.kubernetes.io/name=mediawiki,app.kubernetes.io/component=app-backend -o jsonpath="{.items[0].metadata.name}")
-kubectl exec -it "$MW_POD" -- bash -c "WBS_DOMAIN=$WBS_DOMAIN php w/extensions/Wikibase/repo/maintenance/dumpRdf.php --output /tmp/output.ttl"
+$CLOUD_KUBECTL exec -it "$MW_POD" -- bash -c "WBS_DOMAIN=$TO_WIKI_DOMAIN php w/extensions/Wikibase/repo/maintenance/dumpRdf.php --output /tmp/output.ttl"
 
 ## TODO Copy between pods instead of to local disk
-kubectl cp "$MW_POD":/tmp/output.ttl /tmp/output.ttl
-kubectl cp /tmp/output.ttl "$QS_POD":/tmp/output.ttl
+$CLOUD_KUBECTL cp "$MW_POD":/tmp/output.ttl /tmp/output.ttl
+$CLOUD_KUBECTL cp /tmp/output.ttl "$QS_POD":/tmp/output.ttl
+
+$CLOUD_KUBECTL exec -it "$MW_POD" -- rm /tmp/output.ttl
 
 ## in queryservice
-kubectl exec -it "$QS_POD" -- bash -c "java -cp lib/wikidata-query-tools-*-jar-with-dependencies.jar org.wikidata.query.rdf.tool.Munge --from /tmp/output.ttl --to /tmp/mungeOut/wikidump-%09d.ttl.gz --chunkSize 100000 -w $WBS_DOMAIN
-./loadData.sh -n $QS_NAMESPACE -d /tmp/mungeOut/"
+$CLOUD_KUBECTL exec -it "$QS_POD" -- bash -c "java -cp lib/wikidata-query-tools-*-jar-with-dependencies.jar org.wikidata.query.rdf.tool.Munge --from /tmp/output.ttl --to /tmp/mungeOut/wikidump-%09d.ttl.gz --chunkSize 100000 -w $TO_WIKI_DOMAIN
+./loadData.sh -n $WIKI_QS_NAMESPACE -d /tmp/mungeOut/"
+
+$CLOUD_KUBECTL exec -it "$QS_POD" -- rm -rf /tmp/mungeOut/ /tmp/output.ttl
 
 # TODO get the MAX value in the edit_events table on wbstack.com and add ALL of those IDs to the edit_events_table once site is setup
 # OR


### PR DESCRIPTION
contents of a wikibase and then re-ingesting it through the WDQS munge
and loadData scripts.

This was tried out with 0.3.6 and 0.3.97 but with the same results.

When loading the data there are some distinct differences between the
resulting dataset.

The imported export has additonal dump triples saying that the data was imported.

The http://wikiba.se/ontology#timestamp triples are also missing from each entity.

```
{
	"s": "http://wikibase.wbaas.localhost/entity/Q3",
	"p": "http://wikiba.se/ontology#timestamp",
	"o": "2022-02-02T10:08:24Z"
},
```